### PR TITLE
Explain "none" behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ filesystem copy.
 If necessary, you can force the behaviour to one of the below using the
 `SS_VENDOR_METHOD` environment variable (set in your system environment prior to install):
 
-  - `none` - Disables all symlink / copy
+  - `none` - Disables all symlink / copy (see "Disabling the behaviour")
   - `copy` - Performs a copy only
   - `symlink` - Performs a symlink only
   - `auto` -> Perfrm symlink, but fail over to copy.
 
 Any other value will be treated as `auto` 
+
+## Disabling the behaviour
+
+While `SS_VENDOR_METHOD=none` will disable any symlink/copy operations,
+the module itself will still be installed in `vendor/` like any other composer module.
+This means you need to remove any default URL rewrites in `SimpleResourceURLGenerator.url_rewrites`,
+and whitelist access into specific package folders which the browser needs to access in your own
+rewriting rules (e.g. `.htaccess`). For example, you'll need to whitelist `vendor/silverstripe/admin/client/dist`
+access for the CMS to work. We do not recommend whitelisting the whole `vendor/` folder for public access.


### PR DESCRIPTION
From what I can tell, the module will effectively break core operation by default in `SS_VENDOR_METHOD=none` mode. It doesn't copy/symlink files, but also leaves the default `vendor/` protections in place in `.htacess`. And the resource generator will still rewrite to non-existant URLs in `resources/`. 

Also, while `SS_VENDOR_METHOD=none` is designed as an environment setting, the fact that you have to change the resource generator YAML config effectively binds it to at least an environment type. I guess that's less important than for copy vs. symlink - where different devs might have different preferences in the same environment type (`dev`), e.g. because one runs Windows without symlink support.

This option could be chosen by devs who don't want to change their deployment processes to include this copy operation. I'm wondering if we should just remove it - you'd need to keep a `vendor/*` whitelist that needs to change with every module. 

Alternatively, we would actually need to install the modules in the webroot again if the "none" method is chosen. It looks like you can do that in this module (doesn't need to be packaged with composer): https://getcomposer.org/doc/articles/custom-installers.md#the-custom-installer-class