### PR TITLE
Remove "none" method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ filesystem copy.
 If necessary, you can force the behaviour to one of the below using the
 `SS_VENDOR_METHOD` environment variable (set in your system environment prior to install):
 
-  - `none` - Disables all symlink / copy
   - `copy` - Performs a copy only
   - `symlink` - Performs a symlink only
-  - `auto` -> Perfrm symlink, but fail over to copy.
+  - `auto` -> Perform symlink, but fail over to copy.
 
 Any other value will be treated as `auto` 

--- a/src/VendorPlugin.php
+++ b/src/VendorPlugin.php
@@ -34,11 +34,6 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface
     const METHOD_ENV = 'SS_VENDOR_METHOD';
 
     /**
-     * Method name for "none" option
-     */
-    const METHOD_NONE = 'none';
-
-    /**
      * Method name to auto-attempt best method
      */
     const METHOD_AUTO = 'auto';
@@ -158,9 +153,6 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface
                 return new CopyMethod();
             case SymlinkMethod::NAME:
                 return new SymlinkMethod();
-            case self::METHOD_NONE:
-                // 'none' is forced to an empty chain
-                return new ChainedMethod([]);
             case self::METHOD_AUTO:
             default:
                 // Default to safe-failover method


### PR DESCRIPTION
It's breaking the website operation by default,
and is not easy to fix (need to manually whitelist vendor/ paths).
We would need to replicate the `silverstripe-module`
installer logic to allow legacy-style installation of
`silverstripe-vendormodules` into the webroot.
This would also include core modules, and complicate their
implementation (particularly for framework and main.php paths).

See https://github.com/silverstripe/vendor-plugin/pull/2
for additional rationale.