### PR TITLE
API Add vendor-expose composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ If necessary, you can force the behaviour to one of the below using the
   - `none` - Disables all symlink / copy
   - `copy` - Performs a copy only
   - `symlink` - Performs a symlink only
-  - `auto` -> Perfrm symlink, but fail over to copy.
+  - `junction` - Uses a junction (windows only)
+  - `auto` -> Perfrm symlink (or junction on windows), but fail over to copy.
 
-Any other value will be treated as `auto` 
+## Updating all exposed folders
+
+A custom composer command can be run at any time to update / refresh all 
+
+`composer vendor-expose [<method>]`
+
+You can pass in one of the above methods to force a specific behaviour, otherwise
+the default will be chosen based on either a previously used method,
+or the `SS_VENDOR_METHOD` environment argument. 

--- a/resources/.htaccess
+++ b/resources/.htaccess
@@ -1,3 +1,9 @@
+# Block .method file
+<Files .method>
+    Order Allow,Deny
+    Deny from all
+</Files>
+
 # Block 404s
 <IfModule mod_rewrite.c>
     RewriteCond %{REQUEST_FILENAME} !-f

--- a/src/Console/VendorCommandProvider.php
+++ b/src/Console/VendorCommandProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\VendorPlugin\Console;
+
+use Composer\Command\BaseCommand;
+use Composer\Plugin\Capability\CommandProvider;
+
+class VendorCommandProvider implements CommandProvider
+{
+    /**
+     * Retreives an array of commands
+     *
+     * @return BaseCommand[]
+     */
+    public function getCommands()
+    {
+        return [
+            new VendorExposeCommand()
+        ];
+    }
+}

--- a/src/Console/VendorExposeCommand.php
+++ b/src/Console/VendorExposeCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SilverStripe\VendorPlugin\Console;
+
+use Composer\Command\BaseCommand;
+use Composer\Factory;
+use Composer\IO\ConsoleIO;
+use Composer\Util\Filesystem;
+use SilverStripe\VendorPlugin\Util;
+use SilverStripe\VendorPlugin\VendorExposeTask;
+use SilverStripe\VendorPlugin\VendorModule;
+use SilverStripe\VendorPlugin\VendorPlugin;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides `composer vendor-expose` behaviour
+ */
+class VendorExposeCommand extends BaseCommand
+{
+    public function configure()
+    {
+        $this->setName('vendor-expose');
+        $this->setDescription('Refresh all exposed vendor module folders');
+        $this->addArgument(
+            'method',
+            InputArgument::OPTIONAL,
+            'Optional method to use. Defaults to last used value, or ' . VendorPlugin::METHOD_DEFAULT . ' otherwise'
+        );
+        $this->setHelp('This command will update all resources for all installed modules using the given method');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new ConsoleIO($input, $output, $this->getHelperSet());
+
+        // Check modules to expose
+        $modules = $this->getAllModules();
+        if (empty($modules)) {
+            $io->write("No modules to expose");
+            return;
+        }
+
+        // Expose all modules
+        $method = $input->getArgument('method');
+        $task = new VendorExposeTask($this->getProjectPath(), new Filesystem(), VendorModule::DEFAULT_TARGET);
+        $task->process($io, $modules, $method);
+
+        // Success
+        $io->write("All modules updated!");
+    }
+
+    /**
+     * Find all modules
+     *
+     * @return VendorModule[]
+     */
+    protected function getAllModules()
+    {
+        $modules = [];
+        $basePath = $this->getProjectPath();
+        $search = Util::joinPaths($basePath, 'vendor', '*', '*');
+        foreach (glob($search, GLOB_ONLYDIR) as $modulePath) {
+            // Filter by non-composer folders
+            $composerPath = Util::joinPaths($modulePath, 'composer.json');
+            if (!file_exists($composerPath)) {
+                continue;
+            }
+            // Build module
+            $name = basename($modulePath);
+            $vendor = basename(dirname($modulePath));
+            $module = new VendorModule($basePath, "{$vendor}/{$name}");
+            // Check if this module has folders to expose
+            if ($module->getExposedFolders()) {
+                $modules[] = $module;
+            }
+        }
+        return $modules;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getProjectPath()
+    {
+        return dirname(realpath(Factory::getComposerFile()));
+    }
+}

--- a/src/Methods/CopyMethod.php
+++ b/src/Methods/CopyMethod.php
@@ -50,6 +50,7 @@ class CopyMethod implements ExposeMethod
             return copy($source, $target);
         }
         $it = new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS);
+        /** @var RecursiveDirectoryIterator $ri */
         $ri = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::SELF_FIRST);
         $this->filesystem->ensureDirectoryExists($target);
         $result = true;

--- a/src/Methods/JunctionMethod.php
+++ b/src/Methods/JunctionMethod.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\VendorPlugin\Methods;
+
+use Composer\Util\Platform;
+use RuntimeException;
+
+/**
+ * Expose the vendor module resources via a symlink
+ */
+class JunctionMethod extends SymlinkMethod
+{
+    const NAME = 'junction';
+
+    protected function createLink($source, $target)
+    {
+        if (!Platform::isWindows()) {
+            throw new RuntimeException("Cannot create junction on non-windows environment");
+        }
+        $this->filesystem->junction($source, $target);
+
+        // Check if this command succeeded
+        $success = $this->filesystem->isJunction($target);
+        if (!$success) {
+            throw new RuntimeException("Could not create symlink at $target");
+        }
+    }
+}

--- a/src/Methods/SymlinkMethod.php
+++ b/src/Methods/SymlinkMethod.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\VendorPlugin\Methods;
 
 use Composer\Util\Filesystem;
-use Composer\Util\Platform;
 use RuntimeException;
 
 /**
@@ -33,9 +32,7 @@ class SymlinkMethod implements ExposeMethod
         $this->filesystem->ensureDirectoryExists($parent);
 
         // Ensure symlink exists
-        if (!$this->relativeSymlink($source, $target)) {
-            throw new RuntimeException("Could not create symlink at $target");
-        }
+        $this->createLink($source, $target);
     }
 
     /**
@@ -43,14 +40,12 @@ class SymlinkMethod implements ExposeMethod
      *
      * @param string $source File source
      * @param string $target Place to put symlink
-     * @return bool
      */
-    protected function relativeSymlink($source, $target)
+    protected function createLink($source, $target)
     {
-        if (Platform::isWindows()) {
-            $this->filesystem->junction($source, $target);
-            return true;
+        $success = $this->filesystem->relativeSymlink($source, $target);
+        if (!$success) {
+            throw new RuntimeException("Could not create symlink at $target");
         }
-        return $this->filesystem->relativeSymlink($source, $target);
     }
 }

--- a/src/VendorExposeTask.php
+++ b/src/VendorExposeTask.php
@@ -1,0 +1,212 @@
+<?php
+
+
+namespace SilverStripe\VendorPlugin;
+
+use Composer\IO\IOInterface;
+use Composer\Util\Filesystem;
+use Composer\Util\Platform;
+use DirectoryIterator;
+use InvalidArgumentException;
+use SilverStripe\VendorPlugin\Methods\ChainedMethod;
+use SilverStripe\VendorPlugin\Methods\CopyMethod;
+use SilverStripe\VendorPlugin\Methods\ExposeMethod;
+use SilverStripe\VendorPlugin\Methods\JunctionMethod;
+use SilverStripe\VendorPlugin\Methods\SymlinkMethod;
+
+/**
+ * Task for exposing all vendor paths
+ */
+class VendorExposeTask
+{
+    /**
+     * Absolute filesystem path to root folder
+     *
+     * @var string
+     */
+    protected $basePath = null;
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Name of resources folder
+     *
+     * @var string
+     */
+    protected $resourcesFolder;
+
+    /**
+     * Construct task for the given base folder
+     *
+     * @param string $basePath
+     * @param Filesystem $filesystem
+     * @param string $resourcesFolder Base name of 'resources' folder
+     */
+    public function __construct($basePath, Filesystem $filesystem, $resourcesFolder)
+    {
+        $this->basePath = $basePath;
+        $this->filesystem = $filesystem;
+        $this->resourcesFolder = $resourcesFolder;
+    }
+
+    /**
+     * Expose all modules with the given method
+     *
+     * @param IOInterface $io
+     * @param VendorModule[] $modules
+     * @param string $methodKey Method key, or null to auto-detect from environment
+     */
+    public function process(IOInterface $io, array $modules, $methodKey = null)
+    {
+        // No-op
+        if (empty($modules)) {
+            return;
+        }
+
+        // Setup root folder
+        $this->setupResources($io);
+
+        // Get or choose method
+        if (!$methodKey) {
+            $methodKey = $this->getMethodKey();
+        }
+        $method = $this->getMethod($methodKey);
+
+        // Update all modules
+        foreach ($modules as $module) {
+            $name = $module->getName();
+            $io->write(
+                "Exposing web directories for module <info>{$name}</info> with method <info>{$methodKey}</info>:"
+            );
+            foreach ($module->getExposedFolders() as $folder) {
+                $io->write("  - <info>$folder</info>");
+            }
+
+            // Expose web dirs with given method
+            $module->exposePaths($method);
+        }
+
+        // On success, write `.method` token to persist for subsequent updates
+        $this->saveMethodKey($methodKey);
+    }
+
+
+    /**
+     * Ensure the resources folder is safely created and protected from index.php in root
+     *
+     * @param IOInterface $io
+     */
+    protected function setupResources(IOInterface $io)
+    {
+        // Setup root dir
+        $resourcesPath = $this->getResourcesPath();
+        $this->filesystem->ensureDirectoryExists($resourcesPath);
+
+        // Copy missing resources
+        $files = new DirectoryIterator(__DIR__.'/../resources');
+        foreach ($files as $file) {
+            $targetPath = $resourcesPath . DIRECTORY_SEPARATOR . $file->getFilename();
+            if ($file->isFile() && !file_exists($targetPath)) {
+                $name = $file->getFilename();
+                $io->write("Writing <info>{$name}</info> to resources folder");
+                copy($file->getPathname(), $targetPath);
+            }
+        }
+    }
+
+    /**
+     * Get named method instance
+     *
+     * @param string $key Key of method to use
+     * @return ExposeMethod
+     */
+    protected function getMethod($key)
+    {
+        switch ($key) {
+            case CopyMethod::NAME:
+                return new CopyMethod();
+            case SymlinkMethod::NAME:
+                return new SymlinkMethod();
+            case JunctionMethod::NAME:
+                return new JunctionMethod();
+            case VendorPlugin::METHOD_NONE:
+                // 'none' is forced to an empty chain
+                return new ChainedMethod([]);
+            case VendorPlugin::METHOD_AUTO:
+                // Default to safe-failover method
+                if (Platform::isWindows()) {
+                    // Use junctions on windows environment
+                    return new ChainedMethod(new JunctionMethod(), new CopyMethod());
+                } else {
+                    // Use symlink on non-windows environments
+                    return new ChainedMethod(new SymlinkMethod(), new CopyMethod());
+                }
+            default:
+                throw new InvalidArgumentException("Invalid method: {$key}");
+        }
+    }
+
+
+    /**
+     * Get 'key' of method to use
+     *
+     * @return string
+     */
+    protected function getMethodKey()
+    {
+        // Switch if `resources/.method` contains a file
+        $methodFilePath = $this->getMethodFilePath();
+        if (file_exists($methodFilePath) && is_readable($methodFilePath)) {
+            return trim(file_get_contents($methodFilePath));
+        }
+
+        // Switch based on SS_VENDOR_METHOD arg
+        $method = getenv(VendorPlugin::METHOD_ENV);
+        if ($method) {
+            return $method;
+        }
+
+        // Default method
+        return VendorPlugin::METHOD_DEFAULT;
+    }
+
+    /**
+     * Persist method key to `resources/.method` to set value
+     *
+     * @param string $key
+     */
+    protected function saveMethodKey($key)
+    {
+        $methodFilePath = $this->getMethodFilePath();
+        file_put_contents($methodFilePath, $key);
+    }
+
+    /**
+     * Get path to method cache file
+     *
+     * @return string
+     */
+    protected function getMethodFilePath()
+    {
+        return Util::joinPaths(
+            $this->getResourcesPath(),
+            VendorPlugin::METHOD_FILE
+        );
+    }
+
+    /**
+     * Path to 'resources' folder
+     *
+     * @return string
+     */
+    protected function getResourcesPath()
+    {
+        return Util::joinPaths(
+            $this->basePath,
+            $this->resourcesFolder
+        );
+    }
+}

--- a/tests/Methods/ChainedMethodTest.php
+++ b/tests/Methods/ChainedMethodTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use SilverStripe\VendorPlugin\Methods\ChainedMethod;
 use SilverStripe\VendorPlugin\Methods\CopyMethod;
-use SilverStripe\VendorPlugin\Methods\ExposeMethod;
 use SilverStripe\VendorPlugin\Util;
 
 class ChainedMethodTest extends TestCase

--- a/tests/Methods/CopyMethodTest.php
+++ b/tests/Methods/CopyMethodTest.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\VendorPlugin\Tests\Methods;
 
 use Composer\Util\Filesystem;
-use Composer\Util\Platform;
 use PHPUnit\Framework\TestCase;
 use SilverStripe\VendorPlugin\Methods\CopyMethod;
 use SilverStripe\VendorPlugin\Methods\SymlinkMethod;


### PR DESCRIPTION
Cache any installed method to the `resources/.method` folder so that all subsequent updates follow the prior method by default.

Adds `junction` action for windows.

Improve console output to log method currently being used.

Fixes https://github.com/silverstripe/silverstripe-installer/issues/206