### PR TITLE
BUG Fix symlinks failing on non-vendor modules

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -46,8 +46,8 @@ class Library
      */
     public function __construct($basePath, $libraryPath, $name = null)
     {
-        $this->basePath = $basePath;
-        $this->path = $libraryPath;
+        $this->basePath = realpath($basePath);
+        $this->path = realpath($libraryPath);
         $this->name = $name;
     }
 

--- a/src/VendorPlugin.php
+++ b/src/VendorPlugin.php
@@ -9,7 +9,6 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory;
 use Composer\Installer\PackageEvent;
-use Composer\Installers\Installer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\Capability\CommandProvider;


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7765

Because sometimes $installer->getInstallPath() is relative, so we need realpath() to force to absolute.