### PR TITLE
Better support for symlink on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ If necessary, you can force the behaviour to one of the below using the
   - `copy` - Performs a copy only
   - `symlink` - Performs a symlink only
   - `junction` - Uses a junction (windows only)
-  - `auto` -> Perfrm symlink (or junction on windows), but fail over to copy.
+  - `auto` - Try symlink (and junction on windows), but fail over to copy.
+
+Note: to use `symlink` on Windows, run composer commands with Administrator privileges.
 
 ## Updating all exposed folders
 

--- a/src/Methods/SymlinkMethod.php
+++ b/src/Methods/SymlinkMethod.php
@@ -45,7 +45,14 @@ class SymlinkMethod implements ExposeMethod
     {
         $success = $this->filesystem->relativeSymlink($source, $target);
         if (!$success) {
-            throw new RuntimeException("Could not create symlink at $target");
+            // Try again with an absolute instead of relative symlink, as relative symlinks are not supported
+            // on some php versions on Windows
+            $success = @symlink($source, $target);
+            if (!$success) {
+                throw new RuntimeException(
+                    "Could not create symlink at $target. Try again running with elevated privileges."
+                );
+            }
         }
     }
 }

--- a/src/VendorExposeTask.php
+++ b/src/VendorExposeTask.php
@@ -141,12 +141,10 @@ class VendorExposeTask
                 // 'none' is forced to an empty chain
                 return new ChainedMethod([]);
             case VendorPlugin::METHOD_AUTO:
-                // Default to safe-failover method
+                // Default to safe-failover method: try symlink (and junction on Windows), and finally just copy
                 if (Platform::isWindows()) {
-                    // Use junctions on windows environment
-                    return new ChainedMethod(new JunctionMethod(), new CopyMethod());
+                    return new ChainedMethod(new SymlinkMethod(), new JunctionMethod(), new CopyMethod());
                 } else {
-                    // Use symlink on non-windows environments
                     return new ChainedMethod(new SymlinkMethod(), new CopyMethod());
                 }
             default:


### PR DESCRIPTION
Symlink is supported on Windows, but it requires composer to run as Administrator. So I added that in the Exception message. I also added a failover method inside SymlinkMethod.php to try an absolute symlink if the relative one failed, because until recently, relative symlinks did not work on Windows.

I also added the SymlinkMethod to the auto-method for Windows, then failing over to Junction and finally Copy. Unfortunately people will never see the notice or warning about how running the command as Administrator may enable symlinks, so they'll probably still end up creating junctions most of the time (by failover). Not sure how to change that, perhaps a non-critical notice/warning could be added about that.