### PR TITLE
BUG Don't filter modules by type

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -226,11 +226,6 @@ class Library
     {
         $data = $this->getJson();
 
-        // Only expose if correct type
-        if (empty($data['type']) || !preg_match(VendorPlugin::MODULE_FILTER, $data['type'])) {
-            return [];
-        }
-
         // Get all dirs to expose
         if (empty($data['extra']['expose'])) {
             return [];

--- a/src/VendorPlugin.php
+++ b/src/VendorPlugin.php
@@ -26,12 +26,14 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface, Capable
     /**
      * Default module type
      *
-     * @deprecated 1.3..2.0 Use MODULE_FILTER instead
+     * @deprecated 1.3..2.0 No longer used
      */
     const MODULE_TYPE = 'silverstripe-vendormodule';
 
     /**
      * Filter for matching library types to expose
+     *
+     * @deprecated 1.3..2.0 No longer used
      */
     const MODULE_FILTER = '/^silverstripe\-(\w+)$/';
 
@@ -113,7 +115,7 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface, Capable
     {
         // Ensure package is the valid type
         $package = $this->getOperationPackage($event);
-        if (!$package || !preg_match(self::MODULE_FILTER, $package->getType())) {
+        if (!$package) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7948

Also fixes an issue where root expose was ignored if the `type` wasn't a `silverstripe-` prefix.