### PR TITLE
FIX Skip expose calls when 'none' mode is enabled

### DIFF
--- a/src/Console/VendorExposeCommand.php
+++ b/src/Console/VendorExposeCommand.php
@@ -50,10 +50,11 @@ class VendorExposeCommand extends BaseCommand
         // Expose all modules
         $method = $input->getArgument('method');
         $task = new VendorExposeTask($this->getProjectPath(), new Filesystem(), $basePublicPath);
-        $task->process($io, $modules, $method);
 
-        // Success
-        $io->write("All modules updated!");
+        if ($task->process($io, $modules, $method)) {
+            // Success
+            $io->write("All modules updated!");
+        }
     }
 
     /**

--- a/src/VendorExposeTask.php
+++ b/src/VendorExposeTask.php
@@ -75,6 +75,10 @@ class VendorExposeTask
         }
         $method = $this->getMethod($methodKey);
 
+        if ($methodKey === VendorPlugin::METHOD_NONE) {
+            return;
+        }
+
         // Update all modules
         foreach ($libraries as $module) {
             // Skip this module if no exposure required
@@ -138,8 +142,8 @@ class VendorExposeTask
             case JunctionMethod::NAME:
                 return new JunctionMethod();
             case VendorPlugin::METHOD_NONE:
-                // 'none' is forced to an empty chain
-                return new ChainedMethod([]);
+                // 'none' is forced to an empty chain (and doesn't run anyway)
+                return new ChainedMethod();
             case VendorPlugin::METHOD_AUTO:
                 // Default to safe-failover method
                 if (Platform::isWindows()) {

--- a/src/VendorExposeTask.php
+++ b/src/VendorExposeTask.php
@@ -63,7 +63,7 @@ class VendorExposeTask
     {
         // No-op
         if (empty($libraries)) {
-            return;
+            return false;
         }
 
         // Setup root folder
@@ -76,7 +76,7 @@ class VendorExposeTask
         $method = $this->getMethod($methodKey);
 
         if ($methodKey === VendorPlugin::METHOD_NONE) {
-            return;
+            return false;
         }
 
         // Update all modules
@@ -100,6 +100,8 @@ class VendorExposeTask
 
         // On success, write `.method` token to persist for subsequent updates
         $this->saveMethodKey($methodKey);
+
+        return true;
     }
 
 


### PR DESCRIPTION
Currently the 'none' mode attempts to create an 'empty' `ChainedMethod`, but erroneously passes it an empty array, which is then invoked as a Method itself (causing a breakage).

This PR removes the empty array to fix the error, and also triggers an early exit (since there's no point in looping through the modules if we're not doing anything to them).