### PR TITLE
FIX Update Apache .htaccess for new access directives

### DIFF
--- a/resources/.htaccess
+++ b/resources/.htaccess
@@ -1,7 +1,6 @@
 # Block .method file
 <Files .method>
-    Order Allow,Deny
-    Deny from all
+    Require all denied
 </Files>
 
 # Block 404s


### PR DESCRIPTION
Apache updated the way it handles permissions and access to files at version 2.4
SilverStripe has not updated its default .htaccess files to reflect this however
Most installations have been using mod_access_compat which has meant the (lack of)
update has gone largely unnoticed. However distributions are beginning to drop the
deprecation compatibility support module from their default setups, meaning that
after someone updates their infrastructure, the SilverStripe installation ceases
to be functional due to configuration syntax errors.

This commit seeks to rectify this (in part with another update in silverstripe/recipe-core)
by applying the advice given by Apache at
https://httpd.apache.org/docs/2.4/upgrading.html
and
https://httpd.apache.org/docs/2.4/howto/access.html

Ref: https://github.com/silverstripe/silverstripe-framework/issues/9001
Targetting lowest supported branch, intention is for a "merge-up" to happen afterwards.