### PR TITLE
FIX: Add missing methods to plugin interface

### DIFF
--- a/src/VendorPlugin.php
+++ b/src/VendorPlugin.php
@@ -248,4 +248,18 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface, Capable
         );
         $task->process($IO, [$library]);
     }
+
+    /**
+     * Required by the composer 2 plugin interface
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * Required by the composer 2 plugin interface
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/tests/VendorPluginTest.php
+++ b/tests/VendorPluginTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\VendorPlugin\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SilverStripe\VendorPlugin\VendorPlugin;
+
+class VendorPluginTest extends TestCase
+{
+    /**
+     * The simplest possible test, check that the plugin can be instantiated
+     */
+    public function testInstantiation(): void
+    {
+        new VendorPlugin();
+    }
+}


### PR DESCRIPTION
In the original composer2 fix, these were missed. Funnily enough, our
test suite didn’t cover even this case so I’ve added a minimal failing
test that checks instantiation works.