### PR TITLE
Composer 2 (1.x backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
     - php: 7.4
       env:
        - COMPOSER_SELFUPDATE_ARG=--preview
+    - php: nightly
+      env:
+       - COMPOSER_ARG=--ignore-platform-reqs
+       - COMPOSER_SELFUPDATE_ARG=--preview
 
 fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,25 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
-    - php: 7.2
+    - php: 7.1
+      env:
+       - COMPOSER_SELFUPDATE_ARG=--1
+       - COMPOSER_ARG=--prefer-lowest
+    - php: 7.3
+      env:
+       - COMPOSER_SELFUPDATE_ARG=--1
+    - php: 7.4
+      env:
+       - COMPOSER_SELFUPDATE_ARG=--preview
 
 fast_finish: true
 
 before_script:
   - phpenv rehash
   - export PATH=~/.composer/vendor/bin:$PATH
+  - composer self-update $COMPOSER_SELFUPDATE_ARG
   - composer validate
-  - composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o
-  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer update --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile $COMPOSER_ARG
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
         "lint": "phpcs src/ tests/",
         "lint-clean": "phpcbf src/ tests/"
     },
-    "minimum-stability": "dev",
     "require": {
         "composer/installers": "^1.4",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2"
     },
     "require-dev": {
-        "composer/composer": "^1.5",
-        "phpunit/phpunit": "^5.7"
+        "composer/composer": "^1.5 || ^2@rc",
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require": {
         "composer/installers": "^1.4",
-        "composer-plugin-api": "^1.1 || ^2"
+        "composer-plugin-api": "^1.1 || ^2",
+        "php": "^7.1 || ^8"
     },
     "require-dev": {
         "composer/composer": "^1.5 || ^2@rc",

--- a/src/VendorPlugin.php
+++ b/src/VendorPlugin.php
@@ -248,4 +248,18 @@ class VendorPlugin implements PluginInterface, EventSubscriberInterface, Capable
         );
         $task->process($IO, [$library]);
     }
+
+    /**
+     * Required by the composer 2 plugin interface
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * Required by the composer 2 plugin interface
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/tests/Methods/LibraryTest.php
+++ b/tests/Methods/LibraryTest.php
@@ -12,7 +12,7 @@ class LibraryTest extends TestCase
      */
     public function testResourcesDir($expected, $projectPath)
     {
-        $path = __DIR__ . '/fixtures/projects/' . $projectPath;
+        $path = __DIR__ . '/../fixtures/projects/' . $projectPath;
         $lib = new Library($path, 'vendor/silverstripe/skynet');
         $this->assertEquals($expected, $lib->getResourcesDir());
     }
@@ -29,7 +29,7 @@ class LibraryTest extends TestCase
     public function testInvalidResourceDir()
     {
         $this->expectException(\LogicException::class);
-        $path = __DIR__ . '/fixtures/projects/ss44InvalidResourcesDir';
+        $path = __DIR__ . '/../fixtures/projects/ss44InvalidResourcesDir';
         $lib = new Library($path, 'vendor/silverstripe/skynet');
         $lib->getResourcesDir();
     }

--- a/tests/VendorPluginTest.php
+++ b/tests/VendorPluginTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\VendorPlugin\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SilverStripe\VendorPlugin\VendorPlugin;
+
+class VendorPluginTest extends TestCase
+{
+    /**
+     * The simplest possible test, check that the plugin can be instantiated
+     */
+    public function testInstantiation(): void
+    {
+        new VendorPlugin();
+    }
+}


### PR DESCRIPTION
These commits were originally merged into `master`, which represents `2.x`. Hopefully they'll go green against `1`!