### PR TITLE
Return int from execute

### DIFF
--- a/src/Console/VendorExposeCommand.php
+++ b/src/Console/VendorExposeCommand.php
@@ -40,7 +40,7 @@ class VendorExposeCommand extends BaseCommand
         $modules = $this->getAllLibraries();
         if (empty($modules)) {
             $io->write("No modules to expose");
-            return;
+            return 0;
         }
 
         // Query first library for base destination
@@ -53,6 +53,7 @@ class VendorExposeCommand extends BaseCommand
 
         // Success
         $io->write("All modules updated!");
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Symfony console >=4.4 expects an int back from the execute function or it will throw.

is backwards compatible with earlier versions that allowed int or null

fixes https://github.com/silverstripe/vendor-plugin/issues/39