### PR TITLE
FIX: Don't use realpath() for module and base path

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -46,8 +46,8 @@ class Library
      */
     public function __construct($basePath, $libraryPath, $name = null)
     {
-        $this->basePath = realpath($basePath);
-        $this->path = realpath($libraryPath);
+        $this->basePath = $basePath;
+        $this->path = $libraryPath;
         $this->name = $name;
     }
 


### PR DESCRIPTION
fixes #20 and #34

Is there a particular reason why we have been using realpath in the first place?
Can we not assume that the list of modules given to us are the paths we want?