### PR TITLE
FIX resource 404's not returning styled error page

### DIFF
--- a/resources/.htaccess
+++ b/resources/.htaccess
@@ -3,8 +3,8 @@
     Require all denied
 </Files>
 
-# Block 404s
-<IfModule mod_rewrite.c>
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule .* - [R=404,L]
+# Prevent file listings
+<IfModule mod_dir.c>
+    DirectoryIndex disabled
+    DirectorySlash On
 </IfModule>


### PR DESCRIPTION
When viewing a resources URL which 404's (e.g https://www.silverstripe.com/_resources/themes/app/dist/images/404.jpg) the Apache default error page is shown rather than the SilverStripe provided 404 template.
