### PR TITLE
FIX Correctly handle symlink targets specified with a trailing slash

### DIFF
--- a/src/Methods/SymlinkMethod.php
+++ b/src/Methods/SymlinkMethod.php
@@ -24,6 +24,9 @@ class SymlinkMethod implements ExposeMethod
 
     public function exposeDirectory($source, $target)
     {
+        // Remove trailing slash
+        $target = rtrim($target, DIRECTORY_SEPARATOR);
+
         // Remove destination directory to ensure it is clean
         $this->filesystem->removeDirectory($target);
 

--- a/tests/Methods/SymlinkMethodTest.php
+++ b/tests/Methods/SymlinkMethodTest.php
@@ -66,12 +66,48 @@ class SymlinkMethodTest extends TestCase
         $this->assertDirectoryExists(dirname($target));
     }
 
+    public function testSymlinkTrailingSlash()
+    {
+        $method = new SymlinkMethod();
+        $target = Util::joinPaths($this->root, 'resources', 'client') . DIRECTORY_SEPARATOR;
+        $method->exposeDirectory(
+            realpath(__DIR__.'/../fixtures/source/client/'),
+            $target
+        );
+
+        // Ensure file exists
+        $this->assertFileExists(Util::joinPaths($this->root, 'resources', 'client', 'subfolder', 'somefile.txt'));
+
+        // Folder is NOT a real folder
+        if (Platform::isWindows()) {
+            $this->assertTrue($this->filesystem->isJunction($target));
+        } else {
+            $this->assertTrue($this->filesystem->isSymlinkedDirectory($target));
+        }
+
+        // Parent folder is a real folder
+        $this->assertDirectoryExists(dirname($target));
+    }
+
     public function testRecoversFromCopy()
     {
         $method = new CopyMethod();
         $target = Util::joinPaths($this->root, 'resources', 'client');
         $method->exposeDirectory(
             realpath(__DIR__.'/../fixtures/source/client'),
+            $target
+        );
+
+        // Repeat prior test
+        $this->testSymlink();
+    }
+
+    public function testRecoversFromCopyTrailingSlash()
+    {
+        $method = new CopyMethod();
+        $target = Util::joinPaths($this->root, 'resources', 'client') . DIRECTORY_SEPARATOR;
+        $method->exposeDirectory(
+            realpath(__DIR__.'/../fixtures/source/client/'),
             $target
         );
 


### PR DESCRIPTION
As per the title, fix for #44 