### PR TITLE
FIX Ensure composer.json file exists before reading it

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -185,6 +185,9 @@ class Library
             return $this->json;
         }
         $composer = Util::joinPaths($this->getPath(), 'composer.json');
+        if (!file_exists($composer)) {
+            return [];
+        }
         $file = new JsonFile($composer);
         $this->json = $file->read();
         return $this->json;


### PR DESCRIPTION
Issue https://github.com/silverstripe/vendor-plugin/issues/48

It's a protected method and other methods in this file that use it do `isset()` checks, so this should be safe