### PR TITLE
ENH Set the default resources dir to "_resources"

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -22,7 +22,7 @@ class Library
     /**
      * Default folder where vendor resources will be exposed.
      */
-    const DEFAULT_RESOURCES_DIR = 'resources';
+    const DEFAULT_RESOURCES_DIR = '_resources';
 
     /**
      * Project root

--- a/src/Library.php
+++ b/src/Library.php
@@ -25,12 +25,6 @@ class Library
     const DEFAULT_RESOURCES_DIR = 'resources';
 
     /**
-     * Subfolder to map within public webroot
-     * @deprecated 1.4.0..2.0.0 Use Library::getResourcesDir() instead
-     */
-    const RESOURCES_PATH = self::DEFAULT_RESOURCES_DIR;
-
-    /**
      * Project root
      *
      * @var string

--- a/tests/Methods/LibraryTest.php
+++ b/tests/Methods/LibraryTest.php
@@ -20,7 +20,7 @@ class LibraryTest extends TestCase
     public function resourcesDirProvider()
     {
         return [
-            ['resources', 'ss43'],
+            ['_resources', 'ss43'],
             ['_resources', 'ss44'],
             ['customised-resources-dir', 'ss44WithCustomResourcesDir']
         ];


### PR DESCRIPTION
**DO NOT SQUASH** - the two commits have distinct changelog implications.

## BC breaking changes
- Removed deprecated `Library::RESOURCES_DIR`
- Changed `Library::DEFAULT_RESOURCES_DIR` to "_resources"

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10399