### PR TITLE
DEP Require composer/installers ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.1",
-        "composer/installers": "^1.4",
+        "composer/installers": "^2",
         "composer-plugin-api": "^2"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/silverstripe-config/runs/7736655823?check_suite_focus=true
```
- silverstripe/vendor-plugin 2.x-dev requires composer/installers ^1.4 -> satisfiable by composer/installers[v1.4.0, ..., 1.x-dev].
- silverstripe/framework 5.x-dev requires composer/installers ^2 -> satisfiable by composer/installers[v2.0.0-alpha1, ..., 2.x-dev].
- silverstripe/framework 5.x-dev requires silverstripe/vendor-plugin ^2 -> satisfiable by silverstripe/vendor-plugin[2.x-dev].
```
