### PR TITLE
Revert "DEP Use PHPUnit 11"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "composer/composer": "^2",
-        "phpunit/phpunit": "^11.3",
+        "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^3.7"
     }
 }

--- a/tests/Methods/LibraryTest.php
+++ b/tests/Methods/LibraryTest.php
@@ -4,11 +4,12 @@ namespace SilverStripe\VendorPlugin\Tests\Methods;
 
 use PHPUnit\Framework\TestCase;
 use SilverStripe\VendorPlugin\Library;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class LibraryTest extends TestCase
 {
-    #[DataProvider('resourcesDirProvider')]
+    /**
+     * @dataProvider resourcesDirProvider
+     */
     public function testResourcesDir($expected, $projectPath)
     {
         $path = __DIR__ . '/../fixtures/projects/' . $projectPath;
@@ -16,7 +17,7 @@ class LibraryTest extends TestCase
         $this->assertEquals($expected, $lib->getResourcesDir());
     }
 
-    public static function resourcesDirProvider()
+    public function resourcesDirProvider()
     {
         return [
             ['_resources', 'ss43'],


### PR DESCRIPTION
This reverts https://github.com/silverstripe/vendor-plugin/pull/81


Fixes https://github.com/silverstripe/vendor-plugin/actions/runs/10987233497/job/30501793662
> Your requirements could not be resolved to an installable set of packages.

The tests are only run on PHP versions that aren't compatible with PHPUnit 11

## Issue
- https://github.com/silverstripe/.github/issues/313